### PR TITLE
add error objects to list of places meta can appear

### DIFF
--- a/format/index.md
+++ b/format/index.md
@@ -468,9 +468,13 @@ multiple times.
 ### Meta information <a href="#document-structure-meta" id="document-structure-meta" class="headerlink"></a>
 
 As discussed above, the document **MAY** be extended to include
-meta-information as `"meta"` members in several locations: at the top-level,
-within resource objects, within relationship objects, and within [resource
-identifier objects].
+meta-information as `"meta"` members in several locations:
+
+* at the top-level
+* within resource objects
+* within relationship objects
+* within [resource identifier objects]
+* within [error objects]
 
 All `"meta"` members **MUST** have an object as a value, the contents of which
 can be used for custom extensions.
@@ -1586,6 +1590,7 @@ An error object **MAY** have the following members:
 * `"meta"` - to contain non-standard meta-information about the error.
 
 [attributes]: #document-structure-resource-object-attributes
+[error objects]: #errors
 [relationships]: #document-structure-resource-object-relationships
 [resource relationships]: #document-structure-resource-object-relationships
 [resource links]: #document-structure-resource-object-links


### PR DESCRIPTION
`meta` can appear in error objects now, so this section needed updating. I felt that with the extra item it made more sense to format the list of places `meta` can appear as a bulleted list.
